### PR TITLE
Account recovery fix and readme touch ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Planned functionality for first release include:
 - Universal login
 - Ether less transactions via relayer
 
-###Structure
+### Structure
 This repository is organised as monorepo. 
 
 - [Contracts](https://github.com/EthWorks/UniversalLoginSDK/tree/master/universal-login-contracts) - all contracts used in this project
@@ -21,7 +21,7 @@ This repository is organised as monorepo.
 - [SDK](https://github.com/EthWorks/UniversalLoginSDK/blob/master/universal-login-sdk/README.md) - easy way to communicate with relayer by http protocol
 
 
-##Quick example start 
+## Quick example start 
 
 To install dependencies and build projects run following commands from the main project directory:
 

--- a/universal-login-example/README.md
+++ b/universal-login-example/README.md
@@ -1,8 +1,8 @@
-##Example
+## Example
 
 ### Running example on dev environment (quick option)
 
-To install dependencies and build projects run following commands from the main project directory:
+To install dependencies and build projects, run the following commands from the main project directory:
 
 ```sh
 yarn && yarn build

--- a/universal-login-example/src/services/IdentityService.js
+++ b/universal-login-example/src/services/IdentityService.js
@@ -25,9 +25,9 @@ class IdentityService {
     });
   }
 
-  recover() {
-    const privateKey = ethers.Wallet.createRandom().privateKey;
-    const {address} = new Wallet(privateKey, this.provider);
+  async recover() {
+    this.privateKey = await ethers.Wallet.createRandom().privateKey;
+    const {address} = new Wallet(this.privateKey, this.provider);
     this.deviceAddress = address;
     this.subscription = this.sdk.subscribe('KeyAdded', this.identity.address, (event) => {
       if (event.address == address) {

--- a/universal-login-sdk/README.md
+++ b/universal-login-sdk/README.md
@@ -1,4 +1,4 @@
-##SDK
+## SDK
 
 ### Getting Started
 
@@ -29,7 +29,7 @@ The function will return a pair:
 - `privateKey` - a private key that should be stored on given device as securely as possible
 - `identityAddress` - address of new identity contract
 
-To get address existing identity:
+To get address of existing identity:
 
 ```js
 const identityAddress = await sdk.identityExist('alex.ethereum.eth');
@@ -56,9 +56,9 @@ const transactionId = await sdk.execute(identityAddress, message, privateKey);
 
 The function takes six arguments:
 
-- `identityAddress` - address of that identity that requests execution
-- `message` - a message, in the same format as ethereum transaction, to be executed by the relayer
-- `privateKey` - a private key to be used to sign the transaction, the corresponding public key address needs to be connected to identity
+- `identityAddress` - address of identity that requests execution
+- `message` - a message, in the same format as an ethereum transaction, to be executed by the relayer
+- `privateKey` - a private key to be used to sign the transaction, the corresponding public key address needs to be connected to the identity
 - `gasToken` - address of token to refund relayer
 - `gasPrice` - price of gas 
 - `gasLimit` - limit of gas


### PR DESCRIPTION
Fixed an issue where a recovery code would log you back into your account, but would not allow you to take actions in the DAPP (because the private key wasn't being stored correctly). Made some touch ups to the readmes.